### PR TITLE
Updated placeholder logic

### DIFF
--- a/Example/FLTextView Example/Resources/Base.lproj/Main.storyboard
+++ b/Example/FLTextView Example/Resources/Base.lproj/Main.storyboard
@@ -540,37 +540,45 @@
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="200"/>
                                 <subviews>
                                     <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="djH-rW-mUg" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="33"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="300"/>
                                         <subviews>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8nU-Um-kgw" customClass="FLTextView">
-                                                <rect key="frame" x="0.0" y="0.0" width="600" height="33"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="600" height="50"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" id="4Zt-QL-FCJ"/>
+                                                    <constraint firstAttribute="height" constant="50" id="4Zt-QL-FCJ"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder">
-                                                        <mutableString key="value">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</mutableString>
-                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Placeholder will disappear when you'll tap here"/>
                                                     <userDefinedRuntimeAttribute type="boolean" keyPath="hidesPlaceholderWhenBlablabla" value="YES"/>
                                                     <userDefinedRuntimeAttribute type="boolean" keyPath="hidesPlaceholderWhenEditingBegins" value="YES"/>
                                                 </userDefinedRuntimeAttributes>
                                             </textView>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="oGj-Ed-fVv" customClass="FLTextView">
+                                                <rect key="frame" x="0.0" y="100" width="600" height="50"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="50" id="8ch-L4-BHw"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="hidesPlaceholderWhenEditingBegins" value="NO"/>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Placeholder will disappear when you'll start typing"/>
+                                                </userDefinedRuntimeAttributes>
+                                            </textView>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="8nU-Um-kgw" secondAttribute="bottom" id="FSc-7J-FLl"/>
-                                            <constraint firstAttribute="bottom" secondItem="8nU-Um-kgw" secondAttribute="bottom" constant="520" id="LeQ-eo-eyP"/>
+                                            <constraint firstItem="oGj-Ed-fVv" firstAttribute="top" secondItem="8nU-Um-kgw" secondAttribute="bottom" constant="50" id="N4w-ph-0j8"/>
+                                            <constraint firstAttribute="trailing" secondItem="oGj-Ed-fVv" secondAttribute="trailing" id="Roj-M3-WAA"/>
                                             <constraint firstItem="8nU-Um-kgw" firstAttribute="top" secondItem="djH-rW-mUg" secondAttribute="top" id="Vqh-d0-oXG"/>
+                                            <constraint firstAttribute="height" constant="300" id="c0I-Es-3sH"/>
                                             <constraint firstItem="8nU-Um-kgw" firstAttribute="leading" secondItem="djH-rW-mUg" secondAttribute="leading" id="cRW-ue-8Gx"/>
                                             <constraint firstAttribute="trailing" secondItem="8nU-Um-kgw" secondAttribute="trailing" id="dZl-Vq-ZTF"/>
+                                            <constraint firstItem="oGj-Ed-fVv" firstAttribute="leading" secondItem="djH-rW-mUg" secondAttribute="leading" id="yQK-NP-A7c"/>
                                         </constraints>
-                                        <variation key="default">
-                                            <mask key="constraints">
-                                                <exclude reference="LeQ-eo-eyP"/>
-                                            </mask>
-                                        </variation>
                                     </view>
                                 </subviews>
                                 <constraints>

--- a/Example/FLTextView Example/Resources/Base.lproj/Main.storyboard
+++ b/Example/FLTextView Example/Resources/Base.lproj/Main.storyboard
@@ -542,7 +542,7 @@
                                     <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="djH-rW-mUg" userLabel="Content View">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="300"/>
                                         <subviews>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8nU-Um-kgw" customClass="FLTextView">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8nU-Um-kgw" customClass="FLTextView">
                                                 <rect key="frame" x="0.0" y="0.0" width="600" height="50"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>

--- a/FLTextView/FLTextView.swift
+++ b/FLTextView/FLTextView.swift
@@ -67,7 +67,7 @@ public class FLTextView: UITextView {
     /// only when the user starts typing in the text view. 
     
     /// Default value is `false`
-    @IBInspectable public var hidesPlaceholderWhenEditingBegins = false
+    @IBInspectable public var hidesPlaceholderWhenEditingBegins: Bool = false
     
     /// The styled string that is displayed when there is no other text in the text view.
     public var attributedPlaceholder: NSAttributedString? {
@@ -141,7 +141,23 @@ public class FLTextView: UITextView {
     }
     
     func textViewDidBeginEditing(notification: NSNotification) {
-        showPlaceholderViewIfNeeded()
+        if hidesPlaceholderWhenEditingBegins {
+            if isShowingPlaceholder {
+                placeholderView.removeFromSuperview()
+                invalidateIntrinsicContentSize()
+                setContentOffset(CGPointZero, animated: false)
+            }
+        }
+    }
+    
+    func textViewDidEndEditing(notification: NSNotification) {
+        if hidesPlaceholderWhenEditingBegins {
+            if !isShowingPlaceholder && (text == nil || text.isEmpty) {
+                self.addSubview(placeholderView)
+                invalidateIntrinsicContentSize()
+                setContentOffset(CGPointZero, animated: false)
+            }
+        }
     }
     
     // MARK: - UIView
@@ -176,21 +192,25 @@ public class FLTextView: UITextView {
         let notificationCenter = NSNotificationCenter.defaultCenter()
         notificationCenter.addObserver(self, selector: #selector(UITextInputDelegate.textDidChange(_:)), name: UITextViewTextDidChangeNotification, object: self)
         notificationCenter.addObserver(self, selector: #selector(textViewDidBeginEditing(_:)), name: UITextViewTextDidBeginEditingNotification, object: self)
+        notificationCenter.addObserver(self, selector: #selector(textViewDidEndEditing(_:)), name: UITextViewTextDidEndEditingNotification, object: self)
     }
     
     private func showPlaceholderViewIfNeeded() {
-        if hidesPlaceholderWhenEditingBegins || (text != nil && !text.isEmpty && !hidesPlaceholderWhenEditingBegins) {
-            if isShowingPlaceholder {
-                placeholderView.removeFromSuperview()
-            }
-        } else {
-            if !isShowingPlaceholder {
-                addSubview(placeholderView)
+        if !hidesPlaceholderWhenEditingBegins {
+            if text != nil && !text.isEmpty {
+                if isShowingPlaceholder {
+                    placeholderView.removeFromSuperview()
+                    invalidateIntrinsicContentSize()
+                    setContentOffset(CGPointZero, animated: false)
+                }
+            } else {
+                if !isShowingPlaceholder {
+                    addSubview(placeholderView)
+                    invalidateIntrinsicContentSize()
+                    setContentOffset(CGPointZero, animated: false)
+                }
             }
         }
-        
-        invalidateIntrinsicContentSize()
-        setContentOffset(CGPointZero, animated: false)
     }
     
     private func resizePlaceholderView() {

--- a/FLTextView/FLTextView.swift
+++ b/FLTextView/FLTextView.swift
@@ -31,7 +31,7 @@ public class FLTextView: UITextView {
     
     // MARK: - Private Properties
     
-    private let placeholderView = UITextView(frame: CGRectZero)
+    private let placeholderView = UITextView(frame: CGRect.zero)
     
     // MARK: - Placeholder Properties
     
@@ -141,21 +141,19 @@ public class FLTextView: UITextView {
     }
     
     func textViewDidBeginEditing(notification: NSNotification) {
-        if hidesPlaceholderWhenEditingBegins {
-            if isShowingPlaceholder {
-                placeholderView.removeFromSuperview()
-                invalidateIntrinsicContentSize()
-                setContentOffset(CGPointZero, animated: false)
-            }
+        if hidesPlaceholderWhenEditingBegins && isShowingPlaceholder {
+            placeholderView.removeFromSuperview()
+            invalidateIntrinsicContentSize()
+            setContentOffset(CGPoint.zero, animated: false)
         }
     }
     
     func textViewDidEndEditing(notification: NSNotification) {
         if hidesPlaceholderWhenEditingBegins {
             if !isShowingPlaceholder && (text == nil || text.isEmpty) {
-                self.addSubview(placeholderView)
+                addSubview(placeholderView)
                 invalidateIntrinsicContentSize()
-                setContentOffset(CGPointZero, animated: false)
+                setContentOffset(CGPoint.zero, animated: false)
             }
         }
     }
@@ -201,13 +199,13 @@ public class FLTextView: UITextView {
                 if isShowingPlaceholder {
                     placeholderView.removeFromSuperview()
                     invalidateIntrinsicContentSize()
-                    setContentOffset(CGPointZero, animated: false)
+                    setContentOffset(CGPoint.zero, animated: false)
                 }
             } else {
                 if !isShowingPlaceholder {
                     addSubview(placeholderView)
                     invalidateIntrinsicContentSize()
-                    setContentOffset(CGPointZero, animated: false)
+                    setContentOffset(CGPoint.zero, animated: false)
                 }
             }
         }


### PR DESCRIPTION
This logic offers a better isolation of the two placeholder behaviours:
1. when we want to hide the placeholder only after the text changes, we don't do updates at all when the text view begins/ends editing.
2. when we want to hide the placeholder when the text view gets the focus, we do the updates only when the text view begins/ends editing, but not do any updates when the text changes.

See the last section of the example project to check the two behaviours.
